### PR TITLE
Make it more convenient for Mac users, so they only have to set the path to the app

### DIFF
--- a/_Makefile.master
+++ b/_Makefile.master
@@ -74,6 +74,10 @@
 ARD_REV ?= 105
 ARD_HOME ?= /opt/Arduino
 
+ifneq ($(wildcard $(ARD_HOME)/Contents/Resources/Java/hardware/tools/avr/bin/avrdude),)
+	ARD_HOME := $(ARD_HOME)/Contents/Resources/Java
+endif
+
 ifneq ($(wildcard $(ARD_HOME)/hardware/tools/avr/bin/avrdude),)
     ARD_BIN ?= $(ARD_HOME)/hardware/tools/avr/bin
     AVRDUDE ?= $(ARD_BIN)/avrdude


### PR DESCRIPTION
This just makes it more simple for Mac users, so they can set `ARD_HOME` using:

```
ARD_HOME = /Applications/Arduino.app
```

Instead of:

```
ARD_HOME = /Applications/Arduino.app/Contents/Resources/Java
```

This is also how the path looks is in Windows and Linux as well.
