### PR TITLE
Remove any characters after the version number

### DIFF
--- a/_Makefile.master
+++ b/_Makefile.master
@@ -133,7 +133,7 @@ endif
 
 # Read revision from revisions.txt.
 ifndef ARD_REV
-    VERSION = $(shell $(SED) -n 's/ARDUINO \(.*\)/\1/p' < $(ARD_HOME)/revisions.txt | $(CUT) -d " " -f1 | $(HEAD) -1) # Extract version number - it is in the following format: ARDUINO x.x.x
+    VERSION = $(shell $(SED) -n 's/ARDUINO \(.*\)/\1/p' < $(ARD_HOME)/revisions.txt | $(CUT) -d " " -f1 | $(HEAD) -1 | $(CUT) -d "-" -f1) # Extract version number - it is in the following format: ARDUINO x.x.x
     ARD_REV = $(subst .,,$(VERSION)) # Remove punctuation marks
 endif
 


### PR DESCRIPTION
This was needed, as it was "1.5.6-r2"
