### PR TITLE
Fixed Mac bug

### DIFF
--- a/_Makefile.master
+++ b/_Makefile.master
@@ -123,6 +123,8 @@ endif
 # Make if easier for Mac users, so they only have to define the path to the application.
 ifneq ($(wildcard $(ARD_HOME)/Contents/Resources/Java/hardware/tools/avr/bin/avrdude),)
     ARD_HOME := $(ARD_HOME)/Contents/Resources/Java
+else ifneq ($(wildcard $(ARD_HOME)/Contents/Java/hardware/tools/avr/bin/avrdude),)
+    ARD_HOME := $(ARD_HOME)/Contents/Java
 endif
 
 


### PR DESCRIPTION
This caused the error:

``` make
make: *** No rule to make target `sketch_name.ino.cpp', needed by `sketch_name.ino'.  Stop.
```

Please wait by merging this until I am 100% sure that this solves the issue completely. I will be using it all the time for the next month or so and if I haven't experienced the bug by then, then I would say that it's fixed ;)
